### PR TITLE
Add maual index 

### DIFF
--- a/image_sequence_loader.py
+++ b/image_sequence_loader.py
@@ -16,6 +16,7 @@ class ImageSequenceLoader:
                 "exclude_loaded_on_reset": ("BOOLEAN", {"default": False}),
                 "output_alpha": ("BOOLEAN", {"default": False}),
                 "include_extension": ("BOOLEAN", {"default": False}),
+                "start_index": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
             }
         }
@@ -53,7 +54,7 @@ class ImageSequenceLoader:
         else:
             return None, None
 
-    def run(self, folder_path, reset, reset_on_error, seed, loop_or_reset, include_extension, exclude_loaded_on_reset, output_alpha):
+    def run(self, folder_path, reset, reset_on_error, seed, loop_or_reset, include_extension, exclude_loaded_on_reset, output_alpha, start_index):
         random.seed(seed)
 
         if reset or not self.image_files or folder_path != self.prev_folder_path:
@@ -65,7 +66,7 @@ class ImageSequenceLoader:
             return (None, self.current_index, seed, None)
 
         while self.current_index < len(self.image_files):
-            output_image, filename = self._load_image(folder_path, self.current_index, output_alpha)
+            output_image, filename = self._load_image(folder_path, self.current_index+start_index, output_alpha)
             if output_image is not None:
                 break
             elif not reset_on_error:

--- a/image_sequence_loader.py
+++ b/image_sequence_loader.py
@@ -16,7 +16,9 @@ class ImageSequenceLoader:
                 "exclude_loaded_on_reset": ("BOOLEAN", {"default": False}),
                 "output_alpha": ("BOOLEAN", {"default": False}),
                 "include_extension": ("BOOLEAN", {"default": False}),
+                "use_manual_index": ("BOOLEAN", {"default": False}),
                 "start_index": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "manual_index": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
             }
         }
@@ -54,7 +56,7 @@ class ImageSequenceLoader:
         else:
             return None, None
 
-    def run(self, folder_path, reset, reset_on_error, seed, loop_or_reset, include_extension, exclude_loaded_on_reset, output_alpha, start_index):
+    def run(self, folder_path, reset, reset_on_error, seed, loop_or_reset, include_extension, exclude_loaded_on_reset, output_alpha, start_index, use_manual_index, manual_index):
         random.seed(seed)
 
         if reset or not self.image_files or folder_path != self.prev_folder_path:
@@ -66,7 +68,10 @@ class ImageSequenceLoader:
             return (None, self.current_index, seed, None)
 
         while self.current_index < len(self.image_files):
-            output_image, filename = self._load_image(folder_path, self.current_index+start_index, output_alpha)
+            if use_manual_index == False :
+                output_image, filename = self._load_image(folder_path, self.current_index + start_index, output_alpha)
+            else :
+                output_image, filename = self._load_image(folder_path, manual_index + start_index, output_alpha)
             if output_image is not None:
                 break
             elif not reset_on_error:
@@ -91,8 +96,13 @@ class ImageSequenceLoader:
             filename = os.path.splitext(filename)[0]
 
         self.current_index += 1
+        
+        if use_manual_index == False :
+            return_index = self.current_index + start_index - 1
+        else :
+            return_index = manual_index + start_index
 
-        return (output_image, self.current_index + start_index - 1, seed, filename)
+        return (output_image, return_index, seed, filename)
 
 NODE_CLASS_MAPPINGS = {
     "ImageSequenceLoader": ImageSequenceLoader

--- a/image_sequence_loader.py
+++ b/image_sequence_loader.py
@@ -42,7 +42,7 @@ class ImageSequenceLoader:
             filename = self.image_files[index]
             try:
                 with Image.open(image_path) as image:
-                    if alpha == True:
+                    if alpha == False:
                         image = image.convert("RGB")
                     output_image = np.array(image).astype(np.float32) / 255.0
                     output_image = torch.from_numpy(output_image).unsqueeze(0)

--- a/image_sequence_loader.py
+++ b/image_sequence_loader.py
@@ -92,7 +92,7 @@ class ImageSequenceLoader:
 
         self.current_index += 1
 
-        return (output_image, self.current_index - 1, seed, filename)
+        return (output_image, self.current_index + start_index - 1, seed, filename)
 
 NODE_CLASS_MAPPINGS = {
     "ImageSequenceLoader": ImageSequenceLoader


### PR DESCRIPTION
Add a manual index to control multiple Sequence Load nodes at once. If use_manual_index is enabled, the image corresponding to the manual_index will be loaded. When multiple loaders are placed, a single primitive integer node can be incremented to control the number. 

![image](https://github.com/user-attachments/assets/fadca84e-814a-4079-ac52-6caa590bfb4f)
![image](https://github.com/user-attachments/assets/0e187964-7c65-4d03-b53a-5a58ad2674a2)
